### PR TITLE
5 add dark theme

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,15 +9,24 @@
 				--bg-color: #ffffff;
 				--text-color: #333333;
 				--button-bg: #e0e0e0;
+				--link-color: #0066cc;
 			}
 			:root[data-theme="dark"] {
 				--bg-color: #1a1a1a;
 				--text-color: #ffffff;
 				--button-bg: #404040;
+				--link-color: #66b3ff;
 			}
 			body {
 				background-color: var(--bg-color);
 				color: var(--text-color);
+			}
+			a {
+				color: var(--link-color);
+				text-decoration: none;
+			}
+			a:hover {
+				text-decoration: underline;
 			}
 		</style>
 		<script>

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,26 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<style>
+			:root[data-theme="light"] {
+				--bg-color: #ffffff;
+				--text-color: #333333;
+				--button-bg: #e0e0e0;
+			}
+			:root[data-theme="dark"] {
+				--bg-color: #1a1a1a;
+				--text-color: #ffffff;
+				--button-bg: #404040;
+			}
+			body {
+				background-color: var(--bg-color);
+				color: var(--text-color);
+			}
+		</style>
+		<script>
+			const theme = localStorage.getItem('theme') || 'light';
+			document.documentElement.setAttribute('data-theme', theme);
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -1,0 +1,21 @@
+<script>
+    import { theme } from '$lib/stores/theme';
+
+    function toggleTheme() {
+        $theme = $theme === 'light' ? 'dark' : 'light';
+    }
+</script>
+
+<button on:click={toggleTheme} style="padding: 8px; border-radius: 4px; background: var(--button-bg);">
+    {$theme === 'light' ? '🌙' : '☀️'}
+</button>
+
+<style>
+    button {
+        border: none;
+        cursor: pointer;
+    }
+    button:hover {
+        opacity: 0.8;
+    }
+</style>

--- a/src/lib/stores/theme.js
+++ b/src/lib/stores/theme.js
@@ -1,0 +1,14 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const defaultTheme = 'light';
+const initialTheme = browser ? localStorage.getItem('theme') ?? defaultTheme : defaultTheme;
+
+export const theme = writable(initialTheme);
+
+theme.subscribe((value) => {
+    if (browser) {
+        localStorage.setItem('theme', value);
+        document.documentElement.setAttribute('data-theme', value);
+    }
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,23 @@
+<script>
+    import ThemeToggle from '../components/ThemeToggle.svelte';
+</script>
+
+<nav style="padding: 1rem;">
+    <ThemeToggle />
+</nav>
+
+<main>
+    <slot />
+</main>
+
+<style>
+    :global(body) {
+        margin: 0;
+        padding: 20px;
+        transition: background-color 0.3s, color 0.3s;
+    }
+    main {
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+</style>


### PR DESCRIPTION
This pull request introduces a dark mode feature to the application. The changes include adding CSS variables for themes, creating a theme toggle component, and storing the theme preference in local storage.

Key changes include:

### Theme Implementation:

* [`src/app.html`](diffhunk://#diff-c279397c4feb4b0067eda16dfafc3453d18caa9afcc11de4d368411fefc03601R7-R35): Added CSS variables for light and dark themes, and a script to set the theme based on local storage.
* [`src/lib/stores/theme.js`](diffhunk://#diff-4e6d0b627cb98495a83ce96fbb69c4690a1211895399a8ac2e849079789480eeR1-R14): Created a writable Svelte store to manage the theme state and synchronize it with local storage.

### Component Updates:

* [`src/components/ThemeToggle.svelte`](diffhunk://#diff-860741bc71c3b80968073bf29d1c317e02eace6c6694c9d550e70165733fa586R1-R21): Added a new component with a button to toggle between light and dark themes.
* [`src/routes/+layout.svelte`](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR1-R23): Integrated the `ThemeToggle` component into the layout and added global styles for smooth theme transitions.